### PR TITLE
import PropTypes from 'prop-types'

### DIFF
--- a/src/CurrentTimeIndicator.js
+++ b/src/CurrentTimeIndicator.js
@@ -9,9 +9,7 @@ import {
   View,
 } from 'react-native';
 
-const {
-  PropTypes,
-} = React;
+import PropTypes from 'prop-types';
 
 export const CurrentTimeIndicator = React.createClass({
   propTypes: {


### PR DESCRIPTION
Version 15.5 of React Native changes how PropTypes are imported.

Old: 
const {
  PropTypes,
} = React;

New:
import PropTypes from 'prop-types';

Without this fix you will receive the red screen error message "undefined is not an object evaluating ReactPropTypes.string".

Explanation here: https://github.com/facebook/react-native/issues/14590